### PR TITLE
Network status is "NotReachable" on the Windows Phone 8.1 emulator

### DIFF
--- a/EShyMedia.MvvmCross.Plugins.DeviceInfo.WindowsPhone/MvxDeviceInfo.cs
+++ b/EShyMedia.MvvmCross.Plugins.DeviceInfo.WindowsPhone/MvxDeviceInfo.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Windows;
+using Microsoft.Devices;
 using Microsoft.Phone.Info;
 using Microsoft.Phone.Net.NetworkInformation;
+using Environment = System.Environment;
 
 namespace EShyMedia.MvvmCross.Plugins.DeviceInfo.WindowsPhone
 {
@@ -67,6 +69,9 @@ namespace EShyMedia.MvvmCross.Plugins.DeviceInfo.WindowsPhone
         {
             get
             {
+                if (DeviceNetworkInformation.IsNetworkAvailable && Microsoft.Devices.Environment.DeviceType == DeviceType.Emulator)
+                    return NetworkStatus.ReachableViaWiFiNetwork;
+                
                 if (DeviceNetworkInformation.IsWiFiEnabled)
                     return NetworkStatus.ReachableViaWiFiNetwork;
 
@@ -74,7 +79,6 @@ namespace EShyMedia.MvvmCross.Plugins.DeviceInfo.WindowsPhone
                     return NetworkStatus.ReachableViaCarrierDataNetwork;
 
                 return NetworkStatus.NotReachable;
-
             }
         }
     }

--- a/Sample.Core/ViewModels/FirstViewModel.cs
+++ b/Sample.Core/ViewModels/FirstViewModel.cs
@@ -8,13 +8,14 @@ namespace Sample.Core.ViewModels
         : MvxViewModel
     {
         private readonly IMvxDeviceInfo _deviceInfoPlugin;
+        private NetworkStatus _status;
 
         public override void Start()
         {
             base.Start();
 
             DeviceInfo = _deviceInfoPlugin.GetDeviceInfo();
-            var status = _deviceInfoPlugin.NetworkStatus;
+            Status = _deviceInfoPlugin.NetworkStatus;
         }
 
 
@@ -30,5 +31,10 @@ namespace Sample.Core.ViewModels
             set { _deviceInfo = value; RaisePropertyChanged(() => DeviceInfo); }
         }
 
+        public NetworkStatus Status
+        {
+            get { return _status; }
+            private set { _status = value; RaisePropertyChanged(() => Status); }
+        }
     }
 }

--- a/Sample.WindowsPhone/Views/FirstView.xaml
+++ b/Sample.WindowsPhone/Views/FirstView.xaml
@@ -36,6 +36,7 @@
                 <TextBlock Text="{Binding DeviceInfo.Manufacturer}" />
                 <TextBlock Text="{Binding DeviceInfo.DeviceName}" />
                 <TextBlock Text="{Binding DeviceInfo.HardwareId}" />
+                <TextBlock Text="{Binding Status}" />
             </StackPanel>
         </Grid>
     </Grid>


### PR DESCRIPTION
DeviceNetworkInformation returns false for both WiFi and cellular data on the emulator, so the test returns a false negative.

The PR adds a workaround for such a case, so the emulator can be used for testing apps with this plugin. I also extended the WP sample app to see the results.
